### PR TITLE
dynamicpb: Zero() creates RO message

### DIFF
--- a/types/dynamicpb/dynamic.go
+++ b/types/dynamicpb/dynamic.go
@@ -306,8 +306,13 @@ func NewMessageType(desc pref.MessageDescriptor) pref.MessageType {
 	return messageType{desc}
 }
 
-func (mt messageType) New() pref.Message                  { return NewMessage(mt.desc) }
-func (mt messageType) Zero() pref.Message                 { return NewMessage(mt.desc) }
+func (mt messageType) New() pref.Message { return NewMessage(mt.desc) }
+func (mt messageType) Zero() pref.Message {
+	return &Message{
+		typ: messageType{mt.desc},
+		ext: make(map[pref.FieldNumber]pref.FieldDescriptor),
+	}
+}
 func (mt messageType) Descriptor() pref.MessageDescriptor { return mt.desc }
 
 type emptyList struct {


### PR DESCRIPTION
Sets known map to nil so Set fails and IsValid returns false.