### PR TITLE
encoding/protojson: add custom marshall/unmarshall support

### DIFF
--- a/encoding/protojson/encode_test.go
+++ b/encoding/protojson/encode_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/internal/detrand"
 	"google.golang.org/protobuf/internal/flags"
 	"google.golang.org/protobuf/proto"
+	pref "google.golang.org/protobuf/reflect/protoreflect"
 	preg "google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/testing/protopack"
 
@@ -2164,6 +2165,20 @@ func TestMarshal(t *testing.T) {
     }
   ]
 }`,
+	}, {
+		desc: "Marshallers",
+		mo: protojson.MarshalOptions{
+			Marshallers: map[pref.FullName]protojson.MessageMarshaller{
+				(&pb3.JSONNames{}).ProtoReflect().Descriptor().FullName(): func(e protojson.Encoder, m pref.Message) error {
+					value := m.Get((&pb3.JSONNames{}).ProtoReflect().Descriptor().Fields().Get(0))
+					return e.WriteString(value.String())
+				},
+			},
+		},
+		input: &pb3.JSONNames{
+			SString: "string value",
+		},
+		want: `"string value"`,
 	}}
 
 	for _, tt := range tests {

--- a/encoding/protojson/well_known_types.go
+++ b/encoding/protojson/well_known_types.go
@@ -237,9 +237,9 @@ var errMissingType = fmt.Errorf(`missing "@type" field`)
 // It returns errEmptyObject if the JSON object is empty or errMissingType if
 // @type field does not exist. It returns other error if the @type field is not
 // valid or other decoding issues.
-func findTypeURL(d decoder) (json.Token, error) {
+func findTypeURL(d decoder) (Token, error) {
 	var typeURL string
-	var typeTok json.Token
+	var typeTok Token
 	numFields := 0
 	// Skip start object.
 	d.Read()


### PR DESCRIPTION
This PR adds a configuration parameter to both MarshalOptions and UnmarshalOptions that allows the user to define custom encoding/decoding functions for specific message types.

My specific use case of this functionality is to support encoding and decoding of some of the most accepted date types (i.e. https://godoc.org/cloud.google.com/go/civil and https://github.com/googleapis/googleapis/blob/master/google/type/date.proto) into the ISO 8601 format for those types.  Adding to the "well known types" is not an option as the types are not actually well known types.  This also adds flexibility to allow multiple Json values to represent the same deserialized data. (i.e. in this example, the date could be specified as an ISO 8601 string or as an object with a "year", "month" and "day" fields).

Because this relies on the functionality in "internal/encoding/json" package, I have exposed the Kind type and multiple interfaces in the "protojson" package that correspond to the types defined in the internal package.

This should provide sufficient flexibility in implementations.