### PR TITLE
cmd/protoc-gen-go: --version should exit 0

### DIFF
--- a/cmd/protoc-gen-go/main.go
+++ b/cmd/protoc-gen-go/main.go
@@ -24,7 +24,7 @@ import (
 func main() {
 	if len(os.Args) == 2 && os.Args[1] == "--version" {
 		fmt.Fprintf(os.Stderr, "%v %v\n", filepath.Base(os.Args[0]), version.String())
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	var (


### PR DESCRIPTION
Fixes golang/protobuf#1153.