### PR TITLE
feat(protoc-gen-go): make oneof interface name exportable

### DIFF
--- a/cmd/protoc-gen-go/internal_gengo/main.go
+++ b/cmd/protoc-gen-go/internal_gengo/main.go
@@ -791,8 +791,9 @@ func genMessageOneofWrapperTypes(g *protogen.GeneratedFile, f *fileInfo, m *mess
 			continue
 		}
 		ifName := oneofInterfaceName(oneof)
+		ifMethodName := oneofInterfaceMethodName(oneof)
 		g.P("type ", ifName, " interface {")
-		g.P(ifName, "()")
+		g.P(ifMethodName, "()")
 		g.P("}")
 		g.P()
 		for _, field := range oneof.Fields {
@@ -815,7 +816,7 @@ func genMessageOneofWrapperTypes(g *protogen.GeneratedFile, f *fileInfo, m *mess
 			g.P()
 		}
 		for _, field := range oneof.Fields {
-			g.P("func (*", field.GoIdent, ") ", ifName, "() {}")
+			g.P("func (*", field.GoIdent, ") ", ifMethodName, "() {}")
 			g.P()
 		}
 	}
@@ -824,6 +825,12 @@ func genMessageOneofWrapperTypes(g *protogen.GeneratedFile, f *fileInfo, m *mess
 // oneofInterfaceName returns the name of the interface type implemented by
 // the oneof field value types.
 func oneofInterfaceName(oneof *protogen.Oneof) string {
+	return "Is" + oneof.GoIdent.GoName
+}
+
+// oneofInterfaceMethodName returns the method name of the interface type implemented by
+// the oneof field value types.
+func oneofInterfaceMethodName(oneof *protogen.Oneof) string {
 	return "is" + oneof.GoIdent.GoName
 }
 


### PR DESCRIPTION
Signed-off-by: storyicon <yuanchao@bilibili.com>

I am considering whether the interface of the oneof field should be exportable. The reason for this PR is because in previous development, I encountered this problem more than once.

![image](https://user-images.githubusercontent.com/29772821/122541277-0a1a5a80-d05c-11eb-89f5-1566a4a16aca.png)

If it is not exportable, I must write the logic like this:

```go
var route &Route{}
if xxx {
    route.Action = &Route_Route{ ... }
} else if xxx {
    route.Action = &Route_Redirect{ ... }
} else if xxx {
    route.Action = &Route_DirectResponse{ ... }
}
```

This basically limits the `conditional logic` that must be coupled with `assignment statements`.
But if it is exportable, I can write:

```
var route &Route{}
var action IsRoute_Action
if xxx {
    action = &Route_Route{ ... }
} else if xxx {
    action = &Route_Redirect{ ... }
} else if xxx {
    action = &Route_DirectResponse{ ... }
}
route.Action = action
```

Or write it like this:

```
func GetRouteAction() IsRoute_Action {
    if xxx {
        return &Route_Route{ ... }
    } else if xxx {
        return &Route_Redirect{ ... }
    } else if xxx {
        return &Route_DirectResponse{ ... }
    }
}
...

var route = &Route{}
route.Action = GetRouteAction()
```
The biggest difference is that it does not require the assignment of `Action` to be coupled with the `if` or `switch` statement.

I understand the reason for making it private before: don't want user-defined types to be able to populate the oneof field. But in fact, we can achieve the same effect by simply keeping the method private: 
```
type IsRoute_Action interface {
    isRoute_Action()
}
```

This change is from `non-exportable` to `exportable`, so there are no compatibility issues.