### PR TITLE
prototext: Fix parsing of unknown repeated message fields

### DIFF
--- a/encoding/prototext/decode.go
+++ b/encoding/prototext/decode.go
@@ -739,7 +739,9 @@ func (d decoder) skipValue() error {
 			case text.ListClose:
 				return nil
 			case text.MessageOpen:
-				return d.skipMessageValue()
+				if err := d.skipMessageValue(); err != nil {
+					return err
+				}
 			default:
 				// Skip items. This will not validate whether skipped values are
 				// of the same type or not, same behavior as C++

--- a/encoding/prototext/decode_test.go
+++ b/encoding/prototext/decode_test.go
@@ -238,6 +238,11 @@ s_string: "谷歌"
 		inputText:    `unknown_field: { strings: [ [ ] ] }`,
 		wantErr:      `(line 1:29): invalid scalar value: [`,
 	}, {
+		desc:         "unknown list of message field",
+		umo:          prototext.UnmarshalOptions{DiscardUnknown: true},
+		inputMessage: &pb2.Scalars{},
+		inputText:    `unknown_field: [ { a: "b" }, { c: "d" } ]`,
+	}, {
 		desc:         "proto3 message cannot parse field number",
 		umo:          prototext.UnmarshalOptions{DiscardUnknown: true},
 		inputMessage: &pb3.Scalars{},


### PR DESCRIPTION
If `DiscardUnknown` was enabled, previously this syntax was rejected with an error `unexpected token: ]`:

```
  unknown_field: [
    {}
  ]
```

This is because the parser short-circuited after parsing the {}, and didn't handle the closing square brace. Now it no longer short-circuits.