### PR TITLE
Allow json converter to support encoding 64-bit numbers

### DIFF
--- a/encoding/protojson/encode.go
+++ b/encoding/protojson/encode.go
@@ -65,6 +65,9 @@ type MarshalOptions struct {
 	// UseEnumNumbers emits enum values as numbers.
 	UseEnumNumbers bool
 
+	// Allow encode raw int64 and uint64 numbers
+	UseInt64Number bool
+
 	// EmitUnpopulated specifies whether to emit unpopulated fields. It does not
 	// emit unpopulated oneof fields or unpopulated extension fields.
 	// The JSON value emitted for unpopulated fields are as follows:
@@ -306,10 +309,21 @@ func (e encoder) marshalSingular(val protoreflect.Value, fd protoreflect.FieldDe
 	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
 		e.WriteUint(val.Uint())
 
-	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
-		protoreflect.Sfixed64Kind, protoreflect.Fixed64Kind:
-		// 64-bit integers are written out as JSON string.
-		e.WriteString(val.String())
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		if e.opts.UseInt64Number {
+			e.WriteInt(val.Int())
+		} else {
+			// 64-bit integers are written out as JSON string.
+			e.WriteString(val.String())
+		}
+
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		if e.opts.UseInt64Number {
+			e.WriteUint(val.Uint())
+		} else {
+			// 64-bit integers are written out as JSON string.
+			e.WriteString(val.String())
+		}
 
 	case protoreflect.FloatKind:
 		// Encoder.WriteFloat handles the special numbers NaN and infinites.


### PR DESCRIPTION
In my project usage scenario, the client is not js but a mobile terminal, which supports int64. For this type of device using json, can I convert int64 as it is?