### PR TITLE
feat: make it so you can optionally have DiscardUnknown not apply to enums

### DIFF
--- a/encoding/protojson/decode.go
+++ b/encoding/protojson/decode.go
@@ -41,6 +41,10 @@ type UnmarshalOptions struct {
 	// If DiscardUnknown is set, unknown fields and enum name values are ignored.
 	DiscardUnknown bool
 
+	// If ErrorOnUnknownEnumValue is set, unknown enum values will return an error.
+	// this has no effect if DiscardUnknown is false.
+	ErrorOnUnknownEnumValue bool
+
 	// Resolver is used for looking up types when unmarshaling
 	// google.protobuf.Any messages or extension fields.
 	// If nil, this defaults to using protoregistry.GlobalTypes.
@@ -343,7 +347,7 @@ func (d decoder) unmarshalScalar(fd protoreflect.FieldDescriptor) (protoreflect.
 		}
 
 	case protoreflect.EnumKind:
-		if v, ok := unmarshalEnum(tok, fd, d.opts.DiscardUnknown); ok {
+		if v, ok := unmarshalEnum(tok, fd, d.opts.DiscardUnknown, d.opts.ErrorOnUnknownEnumValue); ok {
 			return v, nil
 		}
 
@@ -488,7 +492,7 @@ func unmarshalBytes(tok json.Token) (protoreflect.Value, bool) {
 	return protoreflect.ValueOfBytes(b), true
 }
 
-func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor, discardUnknown bool) (protoreflect.Value, bool) {
+func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor, discardUnknown, errorOnUnknown bool) (protoreflect.Value, bool) {
 	switch tok.Kind() {
 	case json.String:
 		// Lookup EnumNumber based on name.
@@ -496,7 +500,7 @@ func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor, discardUnkno
 		if enumVal := fd.Enum().Values().ByName(protoreflect.Name(s)); enumVal != nil {
 			return protoreflect.ValueOfEnum(enumVal.Number()), true
 		}
-		if discardUnknown {
+		if discardUnknown && !errorOnUnknown {
 			return protoreflect.Value{}, true
 		}
 

--- a/encoding/protojson/decode_test.go
+++ b/encoding/protojson/decode_test.go
@@ -2673,6 +2673,72 @@ func TestUnmarshal(t *testing.T) {
 				10: 101,
 			},
 		},
+	}, /* test ErrorOnUnknownEnumValue undoes DiscardUnknown for enums, but not others */ {
+		desc: "DiscardUnknown: Any, ErrorOnUnknownEnumValue: true",
+		umo: protojson.UnmarshalOptions{
+			DiscardUnknown:          true,
+			ErrorOnUnknownEnumValue: true,
+		},
+		inputMessage: &anypb.Any{},
+		inputText: `{
+  "@type": "foo/pb2.Nested",
+  "unknown": "none"
+}`,
+		wantMessage: &anypb.Any{
+			TypeUrl: "foo/pb2.Nested",
+		},
+	}, {
+		desc: "DiscardUnknown: Any with Empty, ErrorOnUnknownEnumValue: true",
+		umo: protojson.UnmarshalOptions{
+			DiscardUnknown:          true,
+			ErrorOnUnknownEnumValue: true,
+		},
+		inputMessage: &anypb.Any{},
+		inputText: `{
+  "@type": "type.googleapis.com/google.protobuf.Empty",
+  "value": {"unknown": 47}
+}`,
+		wantMessage: &anypb.Any{
+			TypeUrl: "type.googleapis.com/google.protobuf.Empty",
+		},
+	}, {
+		desc:         "DiscardUnknown: true, ErrorOnUnknownEnumValue: true - unknown enum name",
+		inputMessage: &pb3.Enums{},
+		inputText: `{
+  "sEnum": "UNNAMED"
+}`,
+		umo: protojson.UnmarshalOptions{
+			DiscardUnknown:          true,
+			ErrorOnUnknownEnumValue: true,
+		},
+		wantErr: `invalid value for enum field sEnum: "UNNAMED"`, // weak_message2 is unknown since the package containing it is not imported
+	}, {
+		desc:         "DiscardUnknown: true, ErrorOnUnknownEnumValue: true - repeated enum unknown name",
+		inputMessage: &pb2.Enums{},
+		inputText: `{
+  "rptEnum"      : ["TEN", 1, 42, "UNNAMED"]
+}`,
+		umo: protojson.UnmarshalOptions{
+			DiscardUnknown:          true,
+			ErrorOnUnknownEnumValue: true,
+		},
+		wantErr: `invalid value for enum field rptEnum: "UNNAMED"`, // weak_message2 is unknown since the package containing it is not imported
+	}, {
+		desc:         "DiscardUnknown: true, ErrorOnUnknownEnumValue: true - enum map value unknown name",
+		inputMessage: &pb3.Maps{},
+		inputText: `{
+  "uint64ToEnum": {
+    "1" : "ONE",
+	"2" : 2,
+	"10": 101,
+	"3": "UNNAMED"
+  }
+}`,
+		umo: protojson.UnmarshalOptions{
+			DiscardUnknown:          true,
+			ErrorOnUnknownEnumValue: true,
+		},
+		wantErr: `invalid value for enum field value: "UNNAMED"`, // weak_message2 is unknown since the package containing it is not imported
 	}, {
 		desc:         "weak fields",
 		inputMessage: &testpb.TestWeak{},


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf-go/commit/70db1e1de28451dbcc3877e388fda2fbb9e04e00#diff-4bfd19b0e2b567c0f35f87a774a43846bc5b549661d952fb1177867cd762e6ba made it so `DiscardUnknown` also applied to enum values following the discussion https://github.com/golang/protobuf/issues/1208 to comply with the C++ behavior.

The comment by https://github.com/golang/protobuf/issues/1208#issuecomment-698837670 directly applies to my situation in that for historical reasons we had `AllowUnknownFields` set to true in the old `jsonpb` code. This did not affect ENUMS and allowed our service to properly throw a 400 error for invalid ENUM values (yes I know we do not follow best practice of having the zero value be invalid). In the migration to this code we still need `DiscardUnknown` to be true, but also retain the behavior of validating enum fields.

To achieve this I added `ErrorOnUnknownEnumValue` to `UnmarshalOptions` that will still let `DiscardUnknown` apply to field names, but NOT ENUM values. This change will have no affect if `DiscardUnknown` is set to false and no affect on any other field type except enums. I also made the default value of `ErrorOnUnknownEnumValue` retain current behavior if `DiscardUnknown` is set to true.