### PR TITLE
Fix typos

### DIFF
--- a/encoding/protojson/fuzz_test.go
+++ b/encoding/protojson/fuzz_test.go
@@ -64,12 +64,12 @@ func roundTripAndCompareProto(t *testing.T, wireBytes []byte, messages ...proto.
 
 		jsonBytes, err := protojson.Marshal(src)
 		if err != nil {
-			t.Errorf("failed to marshal messsage to json: %v\nmessage: %v", err, src)
+			t.Errorf("failed to marshal message to json: %v\nmessage: %v", err, src)
 		}
 		dst := msg.ProtoReflect().Type().New().Interface()
 
 		if err := protojson.Unmarshal(jsonBytes, dst); err != nil {
-			t.Errorf("failed to unmarshal messsage from json: %v\njson: %s", err, jsonBytes)
+			t.Errorf("failed to unmarshal message from json: %v\njson: %s", err, jsonBytes)
 		}
 
 		// The cmp package does not deal with NaN on its own and will report

--- a/encoding/protojson/well_known_types.go
+++ b/encoding/protojson/well_known_types.go
@@ -60,7 +60,7 @@ func wellKnownTypeMarshaler(name protoreflect.FullName) marshalFunc {
 
 type unmarshalFunc func(decoder, protoreflect.Message) error
 
-// wellKnownTypeUnmarshaler returns a unmarshal function if the message type
+// wellKnownTypeUnmarshaler returns an unmarshal function if the message type
 // has specialized serialization behavior. It returns nil otherwise.
 func wellKnownTypeUnmarshaler(name protoreflect.FullName) unmarshalFunc {
 	if name.Parent() == genid.GoogleProtobuf_package {

--- a/encoding/prototext/fuzz_test.go
+++ b/encoding/prototext/fuzz_test.go
@@ -64,12 +64,12 @@ func roundTripAndCompareProto(t *testing.T, wireBytes []byte, messages ...proto.
 
 		textFormat, err := prototext.Marshal(src)
 		if err != nil {
-			t.Errorf("failed to marshal messsage to text format: %v\nmessage: %v", err, src)
+			t.Errorf("failed to marshal message to text format: %v\nmessage: %v", err, src)
 		}
 		dst := msg.ProtoReflect().Type().New().Interface()
 
 		if err := (prototext.Unmarshal(textFormat, dst)); err != nil {
-			t.Errorf("failed to unmarshal messsage from text format: %v\ntext format: %s", err, textFormat)
+			t.Errorf("failed to unmarshal message from text format: %v\ntext format: %s", err, textFormat)
 		}
 
 		// The cmp package does not deal with NaN on its own and will report

--- a/encoding/protowire/wire_test.go
+++ b/encoding/protowire/wire_test.go
@@ -52,7 +52,7 @@ type (
 	}
 	appendRaw []byte
 
-	// consumeOp represents an Consume operation.
+	// consumeOp represents a Consume operation.
 	consumeOp    = any
 	consumeField struct {
 		wantNum  Number

--- a/internal/cmd/generate-protos/main.go
+++ b/internal/cmd/generate-protos/main.go
@@ -236,7 +236,7 @@ func generateRemoteProtos() {
 
 		// Benchmark protos.
 		// TODO: The protobuf repo no longer includes benchmarks.
-		//       CL removing them says they are superceded by google/fleetbench:
+		//       CL removing them says they are superseded by google/fleetbench:
 		//         https://github.com/protocolbuffers/protobuf/commit/83c499de86224538e5d59adc3d0fa7fdb45b2c72
 		//       But that project's proto benchmark files are very different:
 		//         https://github.com/google/fleetbench/tree/main/fleetbench/proto

--- a/internal/conformance/failing_tests_text_format.txt
+++ b/internal/conformance/failing_tests_text_format.txt
@@ -1,9 +1,9 @@
-Recommended.Editions_Proto3.ProtobufInput.MessageUnknownFields_Print.TextFormatOutput                              # TEXT_FORMAT output we received from test was unparseable.
+Recommended.Editions_Proto3.ProtobufInput.MessageUnknownFields_Print.TextFormatOutput                              # TEXT_FORMAT output we received from test was unparsable.
 Recommended.Editions_Proto3.TextFormatInput.StringLiteralShortUnicodeEscapeSurrogatePairBytes                      # Should have failed to parse, but didn't.
 Recommended.Editions_Proto3.TextFormatInput.StringLiteralShortUnicodeEscapeSurrogatePairString                     # Should have failed to parse, but didn't.
 Recommended.Editions_Proto3.TextFormatInput.StringLiteralUnicodeEscapeSurrogatePairLongShortBytes                  # Should have failed to parse, but didn't.
 Recommended.Editions_Proto3.TextFormatInput.StringLiteralUnicodeEscapeSurrogatePairLongShortString                 # Should have failed to parse, but didn't.
-Recommended.Proto3.ProtobufInput.MessageUnknownFields_Print.TextFormatOutput                                       # TEXT_FORMAT output we received from test was unparseable.
+Recommended.Proto3.ProtobufInput.MessageUnknownFields_Print.TextFormatOutput                                       # TEXT_FORMAT output we received from test was unparsable.
 Recommended.Proto3.TextFormatInput.StringLiteralShortUnicodeEscapeSurrogatePairBytes                               # Should have failed to parse, but didn't.
 Recommended.Proto3.TextFormatInput.StringLiteralShortUnicodeEscapeSurrogatePairString                              # Should have failed to parse, but didn't.
 Recommended.Proto3.TextFormatInput.StringLiteralUnicodeEscapeSurrogatePairLongShortBytes                           # Should have failed to parse, but didn't.

--- a/internal/encoding/tag/tag.go
+++ b/internal/encoding/tag/tag.go
@@ -179,7 +179,7 @@ func Marshal(fd protoreflect.FieldDescriptor, enumName string) string {
 	}
 	tag = append(tag, "name="+name)
 	if jsonName := fd.JSONName(); jsonName != "" && jsonName != name && !fd.IsExtension() {
-		// NOTE: The jsonName != name condition is suspect, but it preserve
+		// NOTE: The jsonName != name condition is suspect, but it preserves
 		// the exact same semantics from the previous generator.
 		tag = append(tag, "json="+jsonName)
 	}

--- a/internal/encoding/text/decode.go
+++ b/internal/encoding/text/decode.go
@@ -335,7 +335,7 @@ func (d *Decoder) parseNext(lastKind Kind) (Token, error) {
 
 		case ListOpen:
 			if lastKind == semicolon {
-				// It is not be possible to have this case as logic here
+				// It is not possible to have this case as logic here
 				// should not have produced a semicolon Token when inside a
 				// list. Let it panic below.
 				break

--- a/internal/encoding/text/decode_test.go
+++ b/internal/encoding/text/decode_test.go
@@ -526,7 +526,7 @@ func TestDecoder(t *testing.T) {
 			},
 		},
 		{
-			// Whitespaces/comments are only allowed betweeb
+			// Whitespaces/comments are only allowed between
 			in: "[" + space + "domain" + space + "." + space + "com # comment\n" +
 				"/" + "pkg" + space + "." + space + "type" + space + "]",
 			want: []R{

--- a/internal/filedesc/build.go
+++ b/internal/filedesc/build.go
@@ -5,7 +5,7 @@
 // Package filedesc provides functionality for constructing descriptors.
 //
 // The types in this package implement interfaces in the protoreflect package
-// related to protobuf descripriptors.
+// related to protobuf descriptors.
 package filedesc
 
 import (
@@ -40,7 +40,7 @@ type Builder struct {
 		protoregistry.ExtensionTypeResolver
 	}
 
-	// FileRegistry is use to lookup file, enum, and message dependencies.
+	// FileRegistry is used to lookup file, enum, and message dependencies.
 	// Once constructed, the file descriptor is registered here.
 	// If nil, it uses protoregistry.GlobalFiles.
 	FileRegistry interface {

--- a/internal/filedesc/editions.go
+++ b/internal/filedesc/editions.go
@@ -33,7 +33,7 @@ func unmarshalGoFeature(b []byte, parent EditionFeatures) EditionFeatures {
 			b = b[m:]
 			parent.GenerateLegacyUnmarshalJSON = protowire.DecodeBool(v)
 		default:
-			panic(fmt.Sprintf("unkown field number %d while unmarshalling GoFeatures", num))
+			panic(fmt.Sprintf("unknown field number %d while unmarshalling GoFeatures", num))
 		}
 	}
 	return parent
@@ -62,7 +62,7 @@ func unmarshalFeatureSet(b []byte, parent EditionFeatures) EditionFeatures {
 			case genid.FeatureSet_JsonFormat_field_number:
 				parent.IsJSONCompliant = v == genid.FeatureSet_ALLOW_enum_value
 			default:
-				panic(fmt.Sprintf("unkown field number %d while unmarshalling FeatureSet", num))
+				panic(fmt.Sprintf("unknown field number %d while unmarshalling FeatureSet", num))
 			}
 		case protowire.BytesType:
 			v, m := protowire.ConsumeBytes(b)
@@ -136,7 +136,7 @@ func unmarshalEditionDefaults(b []byte) {
 			_, m := protowire.ConsumeVarint(b)
 			b = b[m:]
 		default:
-			panic(fmt.Sprintf("unkown field number %d while unmarshalling EditionDefault", num))
+			panic(fmt.Sprintf("unknown field number %d while unmarshalling EditionDefault", num))
 		}
 	}
 }

--- a/internal/impl/codec_extension.go
+++ b/internal/impl/codec_extension.go
@@ -98,7 +98,7 @@ func (f *ExtensionField) canLazy(xt protoreflect.ExtensionType) bool {
 	return false
 }
 
-// isUnexpandedLazy returns true if the ExensionField is lazy and not
+// isUnexpandedLazy returns true if the ExtensionField is lazy and not
 // yet expanded, which means it's present and already checked for
 // initialized required fields.
 func (f *ExtensionField) isUnexpandedLazy() bool {

--- a/internal/impl/lazy_test.go
+++ b/internal/impl/lazy_test.go
@@ -154,7 +154,7 @@ func TestExtensionLazy(t *testing.T) {
 
 	fox := proto.GetExtension(nt, lazytestpb.E_Bat).(*lazytestpb.FlyingFox)
 	if got, want := fox.GetSpecies(), spGH; want != got {
-		t.Errorf("Extension's Speices field not retained, want: %v, got: %v", want, got)
+		t.Errorf("Extension's Species field not retained, want: %v, got: %v", want, got)
 	}
 	if got, want := extensionIsInitialized(t, nt, lazytestpb.E_Bat.Field), true; got != want {
 		t.Errorf("Extension unexpectedly initialized after Get")
@@ -164,7 +164,7 @@ func TestExtensionLazy(t *testing.T) {
 	}
 	foxPup := proto.GetExtension(nt, lazytestpb.E_BatPup).(*lazytestpb.FlyingFox)
 	if got, want := foxPup.GetSpecies(), spP; want != got {
-		t.Errorf("Extension's Speices field not retained, want: %v, got: %v", want, got)
+		t.Errorf("Extension's Species field not retained, want: %v, got: %v", want, got)
 	}
 	if got, want := extensionIsInitialized(t, nt, lazytestpb.E_Bat.Field), true; got != want {
 		t.Errorf("Extension unexpectedly initialized after Get")
@@ -226,7 +226,7 @@ func TestExtensionNestedScopeLazy(t *testing.T) {
 
 	fox := proto.GetExtension(nt, lazytestpb.E_BatNest_Bat).(*lazytestpb.FlyingFox)
 	if got, want := fox.GetSpecies(), spGH; want != got {
-		t.Errorf("Extension's Speices field not retained, want: %v, got: %v", want, got)
+		t.Errorf("Extension's Species field not retained, want: %v, got: %v", want, got)
 	}
 	if got, want := extensionIsInitialized(t, nt, lazytestpb.E_BatNest_Bat.Field), true; got != want {
 		t.Errorf("Extension unexpectedly initialized after Get")
@@ -277,7 +277,7 @@ func TestExtensionRepeatedMessageLazy(t *testing.T) {
 	mrr = roundtrip(t, mr).(*lazytestpb.Tree)
 	foxPosse := proto.GetExtension(mrr, lazytestpb.E_BatPosse).([]*lazytestpb.FlyingFox)
 	if got, want := foxPosse[0].GetSpecies(), spLE; got != want {
-		t.Errorf("Extension's Speices field, want: %v, got: %v", want, got)
+		t.Errorf("Extension's Species field, want: %v, got: %v", want, got)
 	}
 	if got, want := extensionIsInitialized(t, mrr, lazytestpb.E_BatPosse.Field), true; got != want {
 		t.Errorf("Extension unexpectedly initialized after Get")
@@ -424,7 +424,7 @@ func TestExtensionGroupLazy(t *testing.T) {
 	}
 	pipistrelle := proto.GetExtension(mrr, lazytestpb.E_Pipistrelle).(*lazytestpb.Pipistrelle)
 	if got, want := pipistrelle.GetSpecies(), spF; got != want {
-		t.Errorf("Extension's Speices field, want: %v, got: %v", want, got)
+		t.Errorf("Extension's Species field, want: %v, got: %v", want, got)
 	}
 	if got, want := extensionIsInitialized(t, mrr, lazytestpb.E_Pipistrelle.Field), true; got != want {
 		t.Errorf("Extension unexpectedly initialized after Get")
@@ -458,7 +458,7 @@ func TestExtensionGroupLazy(t *testing.T) {
 	mrr = roundtrip(t, mr).(*lazytestpb.Tree)
 	pipistrelles := proto.GetExtension(mrr, lazytestpb.E_Pipistrelles).([]*lazytestpb.Pipistrelles)
 	if got, want := pipistrelles[1].GetSpecies(), spR; got != want {
-		t.Errorf("Extension's Speices field, want: %v, got: %v", want, got)
+		t.Errorf("Extension's Species field, want: %v, got: %v", want, got)
 	}
 	if got, want := extensionIsInitialized(t, mrr, lazytestpb.E_Pipistrelles.Field), true; got != want {
 		t.Errorf("Extension unexpectedly initialized after Get")

--- a/internal/order/range.go
+++ b/internal/order/range.go
@@ -22,7 +22,7 @@ var messageFieldPool = sync.Pool{
 }
 
 type (
-	// FieldRnger is an interface for visiting all fields in a message.
+	// FieldRanger is an interface for visiting all fields in a message.
 	// The protoreflect.Message type implements this interface.
 	FieldRanger interface{ Range(VisitField) }
 	// VisitField is called every time a message field is visited.

--- a/internal/testprotos/legacy/bug1052/bug1052.proto
+++ b/internal/testprotos/legacy/bug1052/bug1052.proto
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// This file exercises a deadlock in registation of legacy extensions:
+// This file exercises a deadlock in registration of legacy extensions:
 // https://github.com/golang/protobuf/issues/1052
 //
 // The corresponding .pb.go file was generated with protoc 3.11.3 and

--- a/internal/testprotos/testeditions/test_extension.pb.go
+++ b/internal/testprotos/testeditions/test_extension.pb.go
@@ -728,8 +728,8 @@ var file_internal_testprotos_testeditions_test_extension_proto_extTypes = []prot
 		ExtendedType:  (*TestFeatureResolution)(nil),
 		ExtensionType: ([]int32)(nil),
 		Field:         3,
-		Name:          "goproto.proto.testeditions.global_packed_extension_overriden",
-		Tag:           "varint,3,rep,packed,name=global_packed_extension_overriden",
+		Name:          "goproto.proto.testeditions.global_packed_extension_overridden",
+		Tag:           "varint,3,rep,packed,name=global_packed_extension_overridden",
 		Filename:      "internal/testprotos/testeditions/test_extension.proto",
 	},
 	{
@@ -744,8 +744,8 @@ var file_internal_testprotos_testeditions_test_extension_proto_extTypes = []prot
 		ExtendedType:  (*TestFeatureResolution)(nil),
 		ExtensionType: ([]int32)(nil),
 		Field:         5,
-		Name:          "goproto.proto.testeditions.RepeatedFieldEncoding.message_packed_extension_overriden",
-		Tag:           "varint,5,rep,packed,name=message_packed_extension_overriden",
+		Name:          "goproto.proto.testeditions.RepeatedFieldEncoding.message_packed_extension_overridden",
+		Tag:           "varint,5,rep,packed,name=message_packed_extension_overridden",
 		Filename:      "internal/testprotos/testeditions/test_extension.proto",
 	},
 }
@@ -864,12 +864,12 @@ var (
 var (
 	// repeated int32 global_expanded_extension = 2;
 	E_GlobalExpandedExtension = &file_internal_testprotos_testeditions_test_extension_proto_extTypes[53]
-	// repeated int32 global_packed_extension_overriden = 3;
-	E_GlobalPackedExtensionOverriden = &file_internal_testprotos_testeditions_test_extension_proto_extTypes[54]
+	// repeated int32 global_packed_extension_overridden = 3;
+	E_GlobalPackedExtensionOverridden = &file_internal_testprotos_testeditions_test_extension_proto_extTypes[54]
 	// repeated int32 message_expanded_extension = 4;
 	E_RepeatedFieldEncoding_MessageExpandedExtension = &file_internal_testprotos_testeditions_test_extension_proto_extTypes[55]
-	// repeated int32 message_packed_extension_overriden = 5;
-	E_RepeatedFieldEncoding_MessagePackedExtensionOverriden = &file_internal_testprotos_testeditions_test_extension_proto_extTypes[56]
+	// repeated int32 message_packed_extension_overridden = 5;
+	E_RepeatedFieldEncoding_MessagePackedExtensionOverridden = &file_internal_testprotos_testeditions_test_extension_proto_extTypes[56]
 )
 
 var File_internal_testprotos_testeditions_test_extension_proto protoreflect.FileDescriptor
@@ -1358,9 +1358,9 @@ var file_internal_testprotos_testeditions_test_extension_proto_depIdxs = []int32
 	0,  // 54: goproto.proto.testeditions.single:extendee -> goproto.proto.testeditions.TestAllExtensions
 	0,  // 55: goproto.proto.testeditions.multi:extendee -> goproto.proto.testeditions.TestAllExtensions
 	3,  // 56: goproto.proto.testeditions.global_expanded_extension:extendee -> goproto.proto.testeditions.TestFeatureResolution
-	3,  // 57: goproto.proto.testeditions.global_packed_extension_overriden:extendee -> goproto.proto.testeditions.TestFeatureResolution
+	3,  // 57: goproto.proto.testeditions.global_packed_extension_overridden:extendee -> goproto.proto.testeditions.TestFeatureResolution
 	3,  // 58: goproto.proto.testeditions.RepeatedFieldEncoding.message_expanded_extension:extendee -> goproto.proto.testeditions.TestFeatureResolution
-	3,  // 59: goproto.proto.testeditions.RepeatedFieldEncoding.message_packed_extension_overriden:extendee -> goproto.proto.testeditions.TestFeatureResolution
+	3,  // 59: goproto.proto.testeditions.RepeatedFieldEncoding.message_packed_extension_overridden:extendee -> goproto.proto.testeditions.TestFeatureResolution
 	1,  // 60: goproto.proto.testeditions.optionalgroup:type_name -> goproto.proto.testeditions.OptionalGroup
 	5,  // 61: goproto.proto.testeditions.optional_nested_message:type_name -> goproto.proto.testeditions.TestAllExtensions.NestedMessage
 	6,  // 62: goproto.proto.testeditions.optional_nested_enum:type_name -> goproto.proto.testeditions.TestAllTypes.NestedEnum

--- a/internal/testprotos/testeditions/test_extension.proto
+++ b/internal/testprotos/testeditions/test_extension.proto
@@ -114,14 +114,14 @@ message TestFeatureResolution {
 
 extend TestFeatureResolution {
   repeated int32 global_expanded_extension = 2;
-  repeated int32 global_packed_extension_overriden = 3
+  repeated int32 global_packed_extension_overridden = 3
       [features.repeated_field_encoding = PACKED];
 }
 
 message RepeatedFieldEncoding {
   extend TestFeatureResolution {
     repeated int32 message_expanded_extension = 4;
-    repeated int32 message_packed_extension_overriden = 5
+    repeated int32 message_packed_extension_overridden = 5
         [features.repeated_field_encoding = PACKED];
   }
 }

--- a/internal/testprotos/testeditions/test_extension2.pb.go
+++ b/internal/testprotos/testeditions/test_extension2.pb.go
@@ -55,8 +55,8 @@ var file_internal_testprotos_testeditions_test_extension2_proto_extTypes = []pro
 		ExtendedType:  (*TestFeatureResolution)(nil),
 		ExtensionType: ([]int32)(nil),
 		Field:         6,
-		Name:          "goproto.proto.testeditions.other_file_global_expanded_extension_overriden",
-		Tag:           "varint,6,rep,name=other_file_global_expanded_extension_overriden",
+		Name:          "goproto.proto.testeditions.other_file_global_expanded_extension_overridden",
+		Tag:           "varint,6,rep,name=other_file_global_expanded_extension_overridden",
 		Filename:      "internal/testprotos/testeditions/test_extension2.proto",
 	},
 	{
@@ -71,8 +71,8 @@ var file_internal_testprotos_testeditions_test_extension2_proto_extTypes = []pro
 		ExtendedType:  (*TestFeatureResolution)(nil),
 		ExtensionType: ([]int32)(nil),
 		Field:         8,
-		Name:          "goproto.proto.testeditions.OtherRepeatedFieldEncoding.other_file_message_expanded_extension_overriden",
-		Tag:           "varint,8,rep,name=other_file_message_expanded_extension_overriden",
+		Name:          "goproto.proto.testeditions.OtherRepeatedFieldEncoding.other_file_message_expanded_extension_overridden",
+		Tag:           "varint,8,rep,name=other_file_message_expanded_extension_overridden",
 		Filename:      "internal/testprotos/testeditions/test_extension2.proto",
 	},
 	{
@@ -87,12 +87,12 @@ var file_internal_testprotos_testeditions_test_extension2_proto_extTypes = []pro
 
 // Extension fields to TestFeatureResolution.
 var (
-	// repeated int32 other_file_global_expanded_extension_overriden = 6;
-	E_OtherFileGlobalExpandedExtensionOverriden = &file_internal_testprotos_testeditions_test_extension2_proto_extTypes[0]
+	// repeated int32 other_file_global_expanded_extension_overridden = 6;
+	E_OtherFileGlobalExpandedExtensionOverridden = &file_internal_testprotos_testeditions_test_extension2_proto_extTypes[0]
 	// repeated int32 other_file_global_packed_extension = 7;
 	E_OtherFileGlobalPackedExtension = &file_internal_testprotos_testeditions_test_extension2_proto_extTypes[1]
-	// repeated int32 other_file_message_expanded_extension_overriden = 8;
-	E_OtherRepeatedFieldEncoding_OtherFileMessageExpandedExtensionOverriden = &file_internal_testprotos_testeditions_test_extension2_proto_extTypes[2]
+	// repeated int32 other_file_message_expanded_extension_overridden = 8;
+	E_OtherRepeatedFieldEncoding_OtherFileMessageExpandedExtensionOverridden = &file_internal_testprotos_testeditions_test_extension2_proto_extTypes[2]
 	// repeated int32 other_file_message_packed_extension = 9;
 	E_OtherRepeatedFieldEncoding_OtherFileMessagePackedExtension = &file_internal_testprotos_testeditions_test_extension2_proto_extTypes[3]
 )
@@ -172,9 +172,9 @@ var file_internal_testprotos_testeditions_test_extension2_proto_goTypes = []any{
 	(*TestFeatureResolution)(nil),      // 1: goproto.proto.testeditions.TestFeatureResolution
 }
 var file_internal_testprotos_testeditions_test_extension2_proto_depIdxs = []int32{
-	1, // 0: goproto.proto.testeditions.other_file_global_expanded_extension_overriden:extendee -> goproto.proto.testeditions.TestFeatureResolution
+	1, // 0: goproto.proto.testeditions.other_file_global_expanded_extension_overridden:extendee -> goproto.proto.testeditions.TestFeatureResolution
 	1, // 1: goproto.proto.testeditions.other_file_global_packed_extension:extendee -> goproto.proto.testeditions.TestFeatureResolution
-	1, // 2: goproto.proto.testeditions.OtherRepeatedFieldEncoding.other_file_message_expanded_extension_overriden:extendee -> goproto.proto.testeditions.TestFeatureResolution
+	1, // 2: goproto.proto.testeditions.OtherRepeatedFieldEncoding.other_file_message_expanded_extension_overridden:extendee -> goproto.proto.testeditions.TestFeatureResolution
 	1, // 3: goproto.proto.testeditions.OtherRepeatedFieldEncoding.other_file_message_packed_extension:extendee -> goproto.proto.testeditions.TestFeatureResolution
 	4, // [4:4] is the sub-list for method output_type
 	4, // [4:4] is the sub-list for method input_type

--- a/internal/testprotos/testeditions/test_extension2.proto
+++ b/internal/testprotos/testeditions/test_extension2.proto
@@ -12,14 +12,14 @@ option go_package = "google.golang.org/protobuf/internal/testprotos/testeditions
 option features.repeated_field_encoding = PACKED;
 
 extend TestFeatureResolution {
-  repeated int32 other_file_global_expanded_extension_overriden = 6
+  repeated int32 other_file_global_expanded_extension_overridden = 6
       [features.repeated_field_encoding = EXPANDED];
   repeated int32 other_file_global_packed_extension = 7;
 }
 
 message OtherRepeatedFieldEncoding {
   extend TestFeatureResolution {
-    repeated int32 other_file_message_expanded_extension_overriden = 8
+    repeated int32 other_file_message_expanded_extension_overridden = 8
         [features.repeated_field_encoding = EXPANDED];
     repeated int32 other_file_message_packed_extension = 9;
   }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -38,7 +38,7 @@ import (
 //     Note that the next CL in step 8 must be submitted after this CL
 //     without any other CLs in-between.
 //
-//  6. Tag a new version, where the tag is is the current String.
+//  6. Tag a new version, where the tag is the current String.
 //
 //  7. Write release notes for all notable changes
 //     between this release and the last release.

--- a/proto/encode.go
+++ b/proto/encode.go
@@ -50,7 +50,7 @@ type MarshalOptions struct {
 	// serializer rather than relying on this API.
 	//
 	// If deterministic serialization is requested, map entries will be
-	// sorted by keys in lexographical order. This is an implementation
+	// sorted by keys in lexicographical order. This is an implementation
 	// detail and subject to change.
 	Deterministic bool
 
@@ -136,7 +136,7 @@ func (o MarshalOptions) Marshal(m Message) ([]byte, error) {
 //	m1.OptionalBytes, _ = proto.Marshal(m2)
 //
 // where they expect the proto2 "optional_bytes" field to be populated
-// if any only if m2 is a valid message.
+// if and only if m2 is a valid message.
 func emptyBytesForMessage(m Message) []byte {
 	if m == nil || !m.ProtoReflect().IsValid() {
 		return nil

--- a/proto/extension_test.go
+++ b/proto/extension_test.go
@@ -394,13 +394,13 @@ func TestFeatureResolution(t *testing.T) {
 		wantPacked bool
 	}{
 		{testeditionspb.E_GlobalExpandedExtension, false},
-		{testeditionspb.E_GlobalPackedExtensionOverriden, true},
+		{testeditionspb.E_GlobalPackedExtensionOverridden, true},
 		{testeditionspb.E_RepeatedFieldEncoding_MessageExpandedExtension, false},
-		{testeditionspb.E_RepeatedFieldEncoding_MessagePackedExtensionOverriden, true},
-		{testeditionspb.E_OtherFileGlobalExpandedExtensionOverriden, false},
+		{testeditionspb.E_RepeatedFieldEncoding_MessagePackedExtensionOverridden, true},
+		{testeditionspb.E_OtherFileGlobalExpandedExtensionOverridden, false},
 		{testeditionspb.E_OtherFileGlobalPackedExtension, true},
 		{testeditionspb.E_OtherRepeatedFieldEncoding_OtherFileMessagePackedExtension, true},
-		{testeditionspb.E_OtherRepeatedFieldEncoding_OtherFileMessageExpandedExtensionOverriden, false},
+		{testeditionspb.E_OtherRepeatedFieldEncoding_OtherFileMessageExpandedExtensionOverridden, false},
 	} {
 		if got, want := tc.input.TypeDescriptor().IsPacked(), tc.wantPacked; got != want {
 			t.Errorf("%v.IsPacked() = %v, want %v", tc.input.TypeDescriptor().FullName(), got, want)

--- a/reflect/protopath/path.go
+++ b/reflect/protopath/path.go
@@ -81,7 +81,7 @@ func (p Values) Index(i int) (out struct {
 	Value protoreflect.Value
 }) {
 	// NOTE: This returns a single struct instead of two return values so that
-	// callers can make use of the the value in an expression:
+	// callers can make use of the value in an expression:
 	//	vs.Index(i).Value.Interface()
 	n := p.Len()
 	if i < 0 {

--- a/reflect/protorange/range.go
+++ b/reflect/protorange/range.go
@@ -194,8 +194,8 @@ func (o Options) rangeAnyMessage(p *protopath.Values, m protoreflect.Message, pu
 		Resolver:     o.Resolver,
 	}.Unmarshal(val, m2.Interface())
 	if errUnmarshal != nil {
-		// If the the underlying message cannot be unmarshaled,
-		// then just treat this as an normal message type.
+		// If the underlying message cannot be unmarshaled,
+		// then just treat this as a normal message type.
 		return false, nil
 	}
 

--- a/reflect/protoreflect/type.go
+++ b/reflect/protoreflect/type.go
@@ -471,7 +471,7 @@ type ExtensionDescriptors interface {
 }
 
 // ExtensionType encapsulates an [ExtensionDescriptor] with a concrete
-// Go implementation. The nested field descriptor must be for a extension field.
+// Go implementation. The nested field descriptor must be for an extension field.
 //
 // While a normal field is a member of the parent message that it is declared
 // within (see [Descriptor.Parent]), an extension field is a member of some other

--- a/reflect/protoreflect/value.go
+++ b/reflect/protoreflect/value.go
@@ -243,7 +243,7 @@ type Map interface {
 	// Has reports whether an entry with the given key is in the map.
 	Has(MapKey) bool
 
-	// Clear clears the entry associated with they given key.
+	// Clear clears the entry associated with the given key.
 	// The operation does nothing if there is no entry associated with the key.
 	//
 	// Clear is a mutating operation and unsafe for concurrent use.

--- a/reflect/protoregistry/registry.go
+++ b/reflect/protoregistry/registry.go
@@ -453,7 +453,7 @@ type MessageTypeResolver interface {
 //
 // The [Types] type implements this interface.
 type ExtensionTypeResolver interface {
-	// FindExtensionByName looks up a extension field by the field's full name.
+	// FindExtensionByName looks up an extension field by the field's full name.
 	// Note that this is the full name of the field as determined by
 	// where the extension is declared and is unrelated to the full name of the
 	// message being extended.
@@ -461,7 +461,7 @@ type ExtensionTypeResolver interface {
 	// This returns (nil, NotFound) if not found.
 	FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error)
 
-	// FindExtensionByNumber looks up a extension field by the field number
+	// FindExtensionByNumber looks up an extension field by the field number
 	// within some parent message, identified by full name.
 	//
 	// This returns (nil, NotFound) if not found.
@@ -657,7 +657,7 @@ func (r *Types) FindMessageByURL(url string) (protoreflect.MessageType, error) {
 	return nil, NotFound
 }
 
-// FindExtensionByName looks up a extension field by the field's full name.
+// FindExtensionByName looks up an extension field by the field's full name.
 // Note that this is the full name of the field as determined by
 // where the extension is declared and is unrelated to the full name of the
 // message being extended.
@@ -700,7 +700,7 @@ func (r *Types) FindExtensionByName(field protoreflect.FullName) (protoreflect.E
 	return nil, NotFound
 }
 
-// FindExtensionByNumber looks up a extension field by the field number
+// FindExtensionByNumber looks up an extension field by the field number
 // within some parent message, identified by full name.
 //
 // This returns (nil, [NotFound]) if not found.

--- a/runtime/protoimpl/version.go
+++ b/runtime/protoimpl/version.go
@@ -46,7 +46,7 @@ const (
 //		_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - genVersion)
 //	)
 //
-// The genVersion is the current minor version used to generated the code.
+// The genVersion is the current minor version used to generate the code.
 // This compile-time check relies on negative integer overflow of a uint
 // being a compilation failure (guaranteed by the Go specification).
 type EnforceVersion uint

--- a/testing/protocmp/util.go
+++ b/testing/protocmp/util.go
@@ -346,7 +346,7 @@ func (f *nameFilters) filterValue(v reflect.Value) bool {
 
 // IgnoreDefaultScalars ignores singular scalars that are unpopulated or
 // explicitly set to the default value.
-// This option does not effect elements in a list or entries in a map.
+// This option does not affect elements in a list or entries in a map.
 //
 // This must be used in conjunction with [Transform].
 func IgnoreDefaultScalars() cmp.Option {

--- a/testing/protopack/pack.go
+++ b/testing/protopack/pack.go
@@ -702,7 +702,7 @@ func formatType(t Type, source bool) (s string) {
 
 // formatString returns a quoted string for s.
 func formatString(s string) string {
-	// Use quoted string if it the same length as a raw string literal.
+	// Use quoted string if it's the same length as a raw string literal.
 	// Otherwise, attempt to use the raw string form.
 	qs := strconv.Quote(s)
 	if len(qs) == 1+len(s)+1 {

--- a/types/descriptorpb/descriptor.pb.go
+++ b/types/descriptorpb/descriptor.pb.go
@@ -69,7 +69,7 @@ const (
 	Edition_EDITION_2023 Edition = 1000
 	Edition_EDITION_2024 Edition = 1001
 	// Placeholder editions for testing feature resolution.  These should not be
-	// used or relyed on outside of tests.
+	// used or relied on outside of tests.
 	Edition_EDITION_1_TEST_ONLY     Edition = 1
 	Edition_EDITION_2_TEST_ONLY     Edition = 2
 	Edition_EDITION_99997_TEST_ONLY Edition = 99997

--- a/types/dynamicpb/types_test.go
+++ b/types/dynamicpb/types_test.go
@@ -143,7 +143,7 @@ func TestDynamicTypesFindExtensionByNameOrNumber(t *testing.T) {
 			t.Fatalf("types.FindExtensionByNumber(%q, %v) = %v", messageName, number, err)
 		}
 		if xt != xt2 {
-			t.Fatalf("FindExtensionByName returned a differet extension than FindExtensionByNumber")
+			t.Fatalf("FindExtensionByName returned a different extension than FindExtensionByNumber")
 		}
 	}
 }

--- a/types/known/apipb/api.pb.go
+++ b/types/known/apipb/api.pb.go
@@ -319,7 +319,7 @@ func (x *Method) GetSyntax() typepb.Syntax {
 // The mixin construct implies that all methods in `AccessControl` are
 // also declared with same name and request/response types in
 // `Storage`. A documentation generator or annotation processor will
-// see the effective `Storage.GetAcl` method after inherting
+// see the effective `Storage.GetAcl` method after inheriting
 // documentation and annotations as follows:
 //
 //	service Storage {

--- a/types/pluginpb/plugin.pb.go
+++ b/types/pluginpb/plugin.pb.go
@@ -280,7 +280,7 @@ type CodeGeneratorResponse struct {
 	// This should be used to indicate errors in .proto files which prevent the
 	// code generator from generating correct code.  Errors which indicate a
 	// problem in protoc itself -- such as the input CodeGeneratorRequest being
-	// unparseable -- should be reported by writing a message to stderr and
+	// unparsable -- should be reported by writing a message to stderr and
 	// exiting with a non-zero status code.
 	Error *string `protobuf:"bytes,1,opt,name=error" json:"error,omitempty"`
 	// A bitmask of supported features that the code generator supports.


### PR DESCRIPTION
Just thought I'd contribute some typo fixes that I stumbled on. Nothing controversial (hopefully).

Use the following command to get a quick and dirty summary of the specific corrections made:
```shell
git diff HEAD^! --word-diff-regex='\w+' -U0 \
  | grep -E '\[\-.*\-\]\{\+.*\+\}' \
  | sed -r 's/.*\[\-(.*)\-\]\{\+(.*)\+\}.*/\1 \2/' \
  | sort | uniq -c | sort -n
```

FWIW, the top typos are:
* overriden (28)
* speices (6)
* messsage (4)
* unparseable (3)
* unkown (3)
* exension (1)
* rnger (1)
* any (1)
* betweeb (1)
* descripriptors (1)
* differet (1)
* inherting (1)
* lexographical (1)
* registation (1)
* relyed (1)
* superceded (1)