### PR TITLE
support nil value by protojson.Marshal

### DIFF
--- a/encoding/protojson/encode_test.go
+++ b/encoding/protojson/encode_test.go
@@ -1213,12 +1213,13 @@ func TestMarshal(t *testing.T) {
 			Kind: &structpb.Value_StructValue{
 				&structpb.Struct{
 					Fields: map[string]*structpb.Value{
-						"null":   {Kind: &structpb.Value_NullValue{}},
-						"number": {Kind: &structpb.Value_NumberValue{}},
-						"string": {Kind: &structpb.Value_StringValue{}},
-						"struct": {Kind: &structpb.Value_StructValue{}},
-						"list":   {Kind: &structpb.Value_ListValue{}},
-						"bool":   {Kind: &structpb.Value_BoolValue{}},
+						"null":          {Kind: &structpb.Value_NullValue{}},
+						"number":        {Kind: &structpb.Value_NumberValue{}},
+						"string":        {Kind: &structpb.Value_StringValue{}},
+						"struct":        {Kind: &structpb.Value_StructValue{}},
+						"list":          {Kind: &structpb.Value_ListValue{}},
+						"bool":          {Kind: &structpb.Value_BoolValue{}},
+						"missing_value": nil,
 					},
 				},
 			},
@@ -1226,6 +1227,7 @@ func TestMarshal(t *testing.T) {
 		want: `{
   "bool": false,
   "list": [],
+  "missing_value": null,
   "null": null,
   "number": 0,
   "string": "",

--- a/encoding/protojson/well_known_types.go
+++ b/encoding/protojson/well_known_types.go
@@ -476,6 +476,11 @@ func (d decoder) unmarshalListValue(m protoreflect.Message) error {
 // Value message needs to be a oneof field set, else it is an error.
 
 func (e encoder) marshalKnownValue(m protoreflect.Message) error {
+	if !m.IsValid() {
+		e.WriteNull()
+		return nil
+	}
+
 	od := m.Descriptor().Oneofs().ByName(genid.Value_Kind_oneof_name)
 	fd := m.WhichOneof(od)
 	if fd == nil {


### PR DESCRIPTION
Currently, when we pass nil as a value to a field of a Struct, we run into the following error when passing it to protojson.Marshal:
```proto: google.protobuf.Value: none of the oneof fields is set```

This pull request resolves this issue.