### PR TITLE
Add Merge to prototext.UnmarshalOptions

### DIFF
--- a/encoding/prototext/decode.go
+++ b/encoding/prototext/decode.go
@@ -31,6 +31,11 @@ func Unmarshal(b []byte, m proto.Message) error {
 type UnmarshalOptions struct {
 	pragma.NoUnkeyedLiterals
 
+	// Merge merges the input into the destination message.
+	// The default behavior is to always reset the message before unmarshaling,
+	// unless Merge is specified.
+	Merge bool
+
 	// AllowPartial accepts input for messages that will result in missing
 	// required fields. If AllowPartial is false (the default), Unmarshal will
 	// return error if there are any missing required fields.
@@ -62,7 +67,9 @@ func (o UnmarshalOptions) Unmarshal(b []byte, m proto.Message) error {
 // For profiling purposes, avoid changing the name of this function or
 // introducing other code paths for unmarshal that do not go through this.
 func (o UnmarshalOptions) unmarshal(b []byte, m proto.Message) error {
-	proto.Reset(m)
+	if !o.Merge {
+		proto.Reset(m)
+	}
 
 	if o.Resolver == nil {
 		o.Resolver = protoregistry.GlobalTypes

--- a/encoding/prototext/decode_test.go
+++ b/encoding/prototext/decode_test.go
@@ -1289,6 +1289,26 @@ str_to_nested: {
 		inputText:    "reserved_field: 'ignore this'",
 		wantMessage:  &pb2.Nests{},
 	}, {
+		desc: "reset message when merge is not set",
+		inputMessage: &pb3.Scalars{
+			SBool: true,
+		},
+		inputText: `s_string: "abc"`,
+		wantMessage: &pb3.Scalars{
+			SString: "abc",
+		},
+	}, {
+		desc: "message not reset when merge is enabled",
+		umo:  prototext.UnmarshalOptions{Merge: true},
+		inputMessage: &pb3.Scalars{
+			SBool: true,
+		},
+		inputText: `s_string: "abc"`,
+		wantMessage: &pb3.Scalars{
+			SBool:   true,
+			SString: "abc",
+		},
+	}, {
 		desc:         "extensions of non-repeated fields",
 		inputMessage: &pb2.Extensions{},
 		inputText: `opt_string: "non-extension field"


### PR DESCRIPTION
This adds a Merge option to prototext.UnmarshalOptions to match proto.UnmarshalOptions.  This is particularly useful when needing to read multiple textproto files of the same format that wrap a single repeated field.

I've added this to the exact same position in the UnmarshalOptions struct as the proto version.  It can be moved to the bottom of the struct definition if that would cause backwards compatibility issues, but I wasn't aware of any.