### PR TITLE
add field name to error

### DIFF
--- a/internal/impl/lazy.go
+++ b/internal/impl/lazy.go
@@ -115,7 +115,7 @@ func (mi *MessageInfo) unmarshalField(b []byte, p pointer, f *coderFieldInfo, la
 				continue
 			}
 			if err != errUnknown {
-				return err
+				return wrapUnmarshalErrorForField(err, mi.Desc, f)
 			}
 		}
 		n := protowire.ConsumeFieldValue(num, wtyp, b)
@@ -356,7 +356,8 @@ func (mi *MessageInfo) unmarshalPointerLazy(b []byte, p pointer, groupTag protow
 		}
 		if err != nil {
 			if err != errUnknown {
-				return out, err
+				return out, wrapUnmarshalErrorForField(err, mi.Desc, f)
+
 			}
 			n = protowire.ConsumeFieldValue(num, wtyp, b)
 			if n < 0 {


### PR DESCRIPTION
This PR wraps un/marshal errors with message and field metadata. If field could not be obtained then message full name is used in other case the full name of the field is used as it also contains the message name. 

Example error:
```go
failed to unmarshal "opaque.goproto.proto.test3.TestAllTypes.singular_bytes": string field contains invalid UTF-8
```
Fixes: 
- https://github.com/golang/protobuf/issues/1228