### PR TITLE
Enhancing Proto-Generated Structs for Gin Framework: Auto-Generating Form Tags Alongside JSON Tags

### DIFF
--- a/cmd/protoc-gen-go/internal_gengo/main.go
+++ b/cmd/protoc-gen-go/internal_gengo/main.go
@@ -756,7 +756,14 @@ func fieldDefaultValue(g *protogen.GeneratedFile, f *fileInfo, m *messageInfo, f
 }
 
 func fieldJSONTagValue(field *protogen.Field) string {
+	if field.Desc.JSONName() == "-" {
+		return "-"
+	}
 	return string(field.Desc.Name()) + ",omitempty"
+}
+
+func fieldFORMTagValue(field *protogen.Field) string {
+	return string(field.Desc.Name())
 }
 
 func genExtensions(g *protogen.GeneratedFile, f *fileInfo) {

--- a/cmd/protoc-gen-go/internal_gengo/main.go
+++ b/cmd/protoc-gen-go/internal_gengo/main.go
@@ -758,6 +758,8 @@ func fieldDefaultValue(g *protogen.GeneratedFile, f *fileInfo, m *messageInfo, f
 func fieldJSONTagValue(field *protogen.Field) string {
 	if field.Desc.JSONName() == "-" {
 		return "-"
+	} else if field.Desc.JSONName() == "MUST" {
+		return string(field.Desc.Name())
 	}
 	return string(field.Desc.Name()) + ",omitempty"
 }

--- a/cmd/protoc-gen-go/internal_gengo/opaque.go
+++ b/cmd/protoc-gen-go/internal_gengo/opaque.go
@@ -85,6 +85,7 @@ func opaqueGenMessageField(g *protogen.GeneratedFile, f *fileInfo, message *mess
 	}
 	protobufTagValue := fieldProtobufTagValue(field)
 	jsonTagValue := fieldJSONTagValue(field)
+	formTagValue := fieldFORMTagValue(field)
 	if g.InternalStripForEditionsDiff() {
 		if field.Desc.ContainingOneof() != nil && field.Desc.ContainingOneof().IsSynthetic() {
 			protobufTagValue = strings.ReplaceAll(protobufTagValue, ",oneof", "")
@@ -96,6 +97,7 @@ func opaqueGenMessageField(g *protogen.GeneratedFile, f *fileInfo, message *mess
 	}
 	if !message.isOpaque() {
 		tags = append(tags, structTags{{"json", jsonTagValue}}...)
+		tags = append(tags, structTags{{"form", formTagValue}}...)
 	}
 	if field.Desc.IsMap() {
 		keyTagValue := fieldProtobufTagValue(field.Message.Fields[0])


### PR DESCRIPTION
平常使用gin框架开发，gin内置ShouldBindJSON和ShouldBindQuery方法。使用它们可以很方便的绑定标签带有json标签和 form标签的字段，但proto自动生成结构体只有json标签，没有form标签，在开发的时候很不方便，所以希望在生成json标签时也生成form标签。

在开发时，有些字段虽然存在有效值，但是在序列化时希望隐藏它，使用json选项json_name="-"实现这个逻辑，这次提交没有增加字段，对原有逻辑的影响约等于无，但是开发便捷度却大大增加了。
同理有些字段虽然是零值，但是在序列化时不希望被隐藏，使用json_name="MUST",来实现这个功能。
-----
When developing with the Gin framework, the built-in ShouldBindJSON and ShouldBindQuery methods are commonly used. These methods conveniently bind fields with JSON and form tags. However, Proto-generated structs only include JSON tags and lack form tags, making development less efficient. The goal is to generate form tags alongside JSON tags during generation.

During development, some fields may contain valid values but should be hidden during serialization. This is achieved using the json_name="-" option. This commit does not add new fields, so the impact on existing logic is negligible, while significantly improving development convenience.

Similarly, some fields might be zero-valued but should not be hidden during serialization. This functionality is implemented via json_name="MUST".

This ensures both JSON and form tags are generated for better compatibility with Gin's binding methods.