### PR TITLE
fixed extra plus sign at the end of rawDesc

### DIFF
--- a/cmd/protoc-gen-go/internal_gengo/reflect.go
+++ b/cmd/protoc-gen-go/internal_gengo/reflect.go
@@ -254,11 +254,12 @@ func genFileDescriptor(gen *protogen.Plugin, g *protogen.GeneratedFile, f *fileI
 	// That makes all these messages start with (1<<3 + 2[:LEN])=0x0a
 	// in the wire-format.
 	// See also https://protobuf.dev/programming-guides/encoding/#structure.
-	fmt.Fprint(g, "const ", rawDescVarName(f), `=""`)
+	fmt.Fprint(g, "const ", rawDescVarName(f), `=`)
 	for _, line := range bytes.SplitAfter(b, []byte{'\x0a'}) {
-		g.P("+")
 		fmt.Fprintf(g, "%q", line)
+		g.P("+")
 	}
+	g.P(`""`)
 	g.P()
 
 	if f.needRawDesc {


### PR DESCRIPTION
This PR fixes a compile-time error caused by an extra + at the end of the rawDesc constant.

Issue:
The constant was previously generated as:

    const file_service_proto_rawDesc = "" + "\n" +


which left a dangling + and broke compilation.

Fix:
Updated to:

    const file_service_proto_rawDesc = "\n" + ""


This removes the trailing + and restores valid code.